### PR TITLE
Replaced Deprecated API Endpoint

### DIFF
--- a/bugzilla/agents.py
+++ b/bugzilla/agents.py
@@ -38,4 +38,4 @@ class BugzillaAgent(object):
 
 class BMOAgent(BugzillaAgent):
     def __init__(self, username=None, password=None):
-        super(BMOAgent, self).__init__('https://api-dev.bugzilla.mozilla.org/latest/', username, password)
+        super(BMOAgent, self).__init__('https://bugzilla.mozilla.org/bzapi/', username, password)

--- a/scripts/attach.py
+++ b/scripts/attach.py
@@ -127,7 +127,7 @@ def main():
 
     # Get the API root, default to bugzilla.mozilla.org
     API_ROOT = os.environ.get('BZ_API_ROOT',
-                              'https://api-dev.bugzilla.mozilla.org/latest/')
+                              'https://bugzilla.mozilla.org/bzapi/')
 
     # Authenticate
     username, password = get_credentials()


### PR DESCRIPTION
BzAPI is deprecated however they have added a BzAPI Compatibility Layer at https://bugzilla.mozilla.org/bzapi/